### PR TITLE
Compatibility fixes to km suffix handling and remove `scheduler`

### DIFF
--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -31,7 +31,7 @@ module FlightScheduler
       NUM_REGEX = /\A\d+[km]?\Z/
 
       def run
-        job = JobsRecord.create(script: script_path, min_nodes: opts.nodes, connection: connection)
+        job = JobsRecord.create(script: script_path, min_nodes: nodes_opts, connection: connection)
         puts "Submitted batch job #{job.id}"
       end
 
@@ -62,6 +62,7 @@ module FlightScheduler
       end
 
       def nodes_opts
+        return 1 unless opts.nodes
         if NUM_REGEX.match? opts.nodes
           opts.nodes
         else

--- a/lib/flight_scheduler/commands/queue.rb
+++ b/lib/flight_scheduler/commands/queue.rb
@@ -31,7 +31,7 @@ module FlightScheduler
       extend OutputMode::TLDR::Index
 
       register_column(header: 'JOBID') { |j| j.id }
-      register_column(header: 'PARTITION') { |j| j.schedular.name }
+      register_column(header: 'PARTITION') { |j| j.partition.name }
       register_column(header: 'NAME') { |j| File.basename(j.script) }
       register_column(header: 'USER') { |_| 'TBD' }
       register_column(header: 'ST') { |_| 'TBD' }
@@ -40,7 +40,7 @@ module FlightScheduler
       register_column(header: 'NODELIST(REASON)') { |_| 'TBD' }
 
       def run
-        records = JobsRecord.fetch_all(includes: ['schedular'], connection: connection)
+        records = JobsRecord.fetch_all(includes: ['partition'], connection: connection)
         puts self.class.build_output.render(*records)
       end
     end

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -40,14 +40,10 @@ module FlightScheduler
     attributes :name, :nodes
   end
 
-  class SchedularsRecord < BaseRecord
-    attributes :name
-  end
-
   class JobsRecord < BaseRecord
     attributes :min_nodes, :script
 
-    has_one :schedular, class_name: 'FlightScheduler::SchedularsRecord'
+    has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
   end
 end
 


### PR DESCRIPTION
This is in extension to the work done in #1. Previously it worked, but the regex checking wasn't being applied.

Also the updated version of the server would reject request without a `-N` flag, which has also been fixed. Finally the `SchedulerRecord` has been removed and replaced by `PartitionsRecord`.