### PR TITLE
Allow options to be set via magic comments

### DIFF
--- a/etc/config.reference
+++ b/etc/config.reference
@@ -1,12 +1,30 @@
 # vim: set filetype=ruby:
-# =============================================================================
-# Leave this file in place as a reference.
-# NOTE: Copying this file into place will result in all keys being set to
-# empty string.
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
 #
-# The actual configuration file should be stored as:
-# etc/config.yaml
-# =============================================================================
+# This file is part of Flight Scheduler.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Scheduler is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Scheduler. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Scheduler, please visit:
+# https://github.com/openflighthpc/flight-scheduler
+#===============================================================================
 
 # ==============================================================================
 # CLI "Program" Configuration
@@ -28,6 +46,13 @@ config :base_url
 # implementation and may not be interoperable with latter versions.
 # =============================================================================
 config :api_prefix, default: 'v0'
+
+# =============================================================================
+# Comment Prefix
+# Specify the default prefix magic comment lines start with. The magic comment
+# lines are applied as additional options to the job
+# =============================================================================
+config :comment_prefix, default: 'SBATCH'
 
 # =============================================================================
 # JWT Token

--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -69,9 +69,13 @@ module FlightScheduler
       c.summary = 'List the available partitions'
     end
 
+    MAGIC_BATCH_SLOP = Slop::Options.new.tap do |slop|
+      slop.string '-N', '--nodes', 'The minimum number of required nodes'
+    end
+
     create_command 'batch', 'SCRIPT [ARGS...]' do |c|
       c.summary = 'Schedule a new job to be ran'
-      c.slop.string '-N', '--nodes', 'The minimum number of required nodes'
+      MAGIC_BATCH_SLOP.each { |opt| c.slop.send(:add_option, opt.dup) }
     end
 
     create_command 'cancel', 'JOBID' do |c|

--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -77,6 +77,9 @@ module FlightScheduler
     create_command 'batch', 'SCRIPT [ARGS...]' do |c|
       c.summary = 'Schedule a new job to be ran'
       MAGIC_BATCH_SLOP.each { |opt| c.slop.send(:add_option, opt.dup) }
+      c.slop.string '-C', '--comment-prefix',
+                    'Parse comment lines starting with COMMENT_PREFIX as additional options',
+                    default: 'SBATCH'
     end
 
     create_command 'cancel', 'JOBID' do |c|

--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -79,7 +79,7 @@ module FlightScheduler
       MAGIC_BATCH_SLOP.each { |opt| c.slop.send(:add_option, opt.dup) }
       c.slop.string '-C', '--comment-prefix',
                     'Parse comment lines starting with COMMENT_PREFIX as additional options',
-                    default: 'SBATCH'
+                    default: Config::CACHE.comment_prefix
     end
 
     create_command 'cancel', 'JOBID' do |c|

--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -70,6 +70,7 @@ module FlightScheduler
     end
 
     MAGIC_BATCH_SLOP = Slop::Options.new.tap do |slop|
+      slop.parser.config[:suppress_errors] = true
       slop.string '-N', '--nodes', 'The minimum number of required nodes'
     end
 

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -77,17 +77,13 @@ module FlightScheduler
       end
 
       def read_magic_arguments_string
-        ''.tap do |args|
-          File.open(script_path) do |file|
-            regex = /\A##{opts.comment_prefix}(?<args>.*)$/
-            while (line = file.gets.to_s)[0] == '#'
-              if match = regex.match(line)
-                args << match.named_captures['args']
-                args << ' '
-              end
-            end
-          end
-        end
+        regex = /\A##{opts.comment_prefix}(?<args>.*)$/
+        File.read(script_path)
+            .each_line
+            .map { |l| regex.match(l) }
+            .reject(&:nil?)
+            .map { |m| m.named_captures['args'] }
+            .join(' ')
       end
 
       def script_path

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -74,7 +74,7 @@ module FlightScheduler
       def read_magic_arguments_string
         ''.tap do |args|
           File.open(script_path) do |file|
-            regex = /\A#SBATCH(?<args>.*)$/
+            regex = /\A##{opts.comment_prefix}(?<args>.*)$/
             while (line = file.gets.to_s)[0] == '#'
               if match = regex.match(line)
                 args << match.named_captures['args']

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -32,7 +32,10 @@ module FlightScheduler
 
       def run
         ensure_shebang
-        job = JobsRecord.create(script: script_path, min_nodes: min_nodes, connection: connection)
+        job = JobsRecord.create(arguments: args,
+                                script: script_path,
+                                min_nodes: min_nodes,
+                                connection: connection)
         puts "Submitted batch job #{job.id}"
       end
 

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -43,7 +43,9 @@ module FlightScheduler
         File.open(script_path) do |file|
           shebang = file.gets(2).to_s
           raise InputError, <<~ERROR.chomp unless shebang == '#!'
-            The script appears to have an invalid shebang line
+            This does not look like a batch script!
+            The first line must start with #! followed by the interpreter path.
+            For instance: #{Paint["#!/bin/bash", :yellow]}
           ERROR
         end
       end

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -36,28 +36,30 @@ module FlightScheduler
       end
 
       def script_path
-        path = args.first
-        # Handle absolute paths and explicit relative paths
-        if File.absolute_path?(path) || path[0] == '.'
-          path = File.expand_path(path)
-          File.exists?(path) ? path : raise(MissingError, "Could not locate: #{path}")
-        # Handle implicit relative paths
-        elsif File.exists?(p = File.expand_path(path))
-          p
-        # Preform a PATH lookup as a fallback
-        else
-          # Do not assume PATH is correct, only consider absolute paths to be valid
-          roots = ENV.fetch('PATH', '').split(':').select do |root|
-            File.absolute_path?(root.to_s)
-          end
+        @script_path ||= begin
+          path = args.first
+          # Handle absolute paths and explicit relative paths
+          if File.absolute_path?(path) || path[0] == '.'
+            path = File.expand_path(path)
+            File.exists?(path) ? path : raise(MissingError, "Could not locate: #{path}")
+          # Handle implicit relative paths
+          elsif File.exists?(p = File.expand_path(path))
+            p
+          # Preform a PATH lookup as a fallback
+          else
+            # Do not assume PATH is correct, only consider absolute paths to be valid
+            roots = ENV.fetch('PATH', '').split(':').select do |root|
+              File.absolute_path?(root.to_s)
+            end
 
-          # Search for the root directory path
-          root = roots.find do |r|
-            File.exists? File.join(r, path)
-          end
+            # Search for the root directory path
+            root = roots.find do |r|
+              File.exists? File.join(r, path)
+            end
 
-          # Return the absolute path or error
-          root ? File.join(root, path) : raise(MissingError, "Could not locate: #{path}")
+            # Return the absolute path or error
+            root ? File.join(root, path) : raise(MissingError, "Could not locate: #{path}")
+          end
         end
       end
 

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -45,6 +45,22 @@ module FlightScheduler
         end
       end
 
+      def magic_arguments_string
+        @magic_arguments_string ||= begin
+          ''.tap do |args|
+            File.open(script_path) do |file|
+              regex = /\A#SBATCH(?<args>.*)$/
+              while (line = file.gets.to_s)[0] == '#'
+                if match = regex.match(line)
+                  args << match.named_captures['args']
+                  args << ' '
+                end
+              end
+            end
+          end
+        end
+      end
+
       def script_path
         @script_path ||= begin
           path = args.first

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -31,8 +31,18 @@ module FlightScheduler
       NUM_REGEX = /\A\d+[km]?\Z/
 
       def run
+        ensure_shebang
         job = JobsRecord.create(script: script_path, min_nodes: nodes_opts, connection: connection)
         puts "Submitted batch job #{job.id}"
+      end
+
+      def ensure_shebang
+        File.open(script_path) do |file|
+          shebang = file.gets(2).to_s
+          raise InputError, <<~ERROR.chomp unless shebang == '#!'
+            The script appears to have an invalid shebang line
+          ERROR
+        end
       end
 
       def script_path

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -77,13 +77,16 @@ module FlightScheduler
       end
 
       def read_magic_arguments_string
-        regex = /\A##{opts.comment_prefix}\s(?<args>.*)$/
-        File.read(script_path)
-            .each_line
-            .map { |l| regex.match(l) }
-            .reject(&:nil?)
-            .map { |m| m.named_captures['args'] }
-            .join(' ')
+        args = []
+        magic_comment_marker = "##{opts.comment_prefix} "
+        File.open(script_path) do |f|
+          while line = f.gets
+            if line.start_with?(magic_comment_marker)
+              args << line.sub(magic_comment_marker, '').chomp
+            end
+          end
+        end
+        args.join(' ')
       end
 
       def script_path

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -77,7 +77,7 @@ module FlightScheduler
       end
 
       def read_magic_arguments_string
-        regex = /\A##{opts.comment_prefix}(?<args>.*)$/
+        regex = /\A##{opts.comment_prefix}\s(?<args>.*)$/
         File.read(script_path)
             .each_line
             .map { |l| regex.match(l) }

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -41,7 +41,7 @@ module FlightScheduler
   end
 
   class JobsRecord < BaseRecord
-    attributes :min_nodes, :script
+    attributes :min_nodes, :script, :arguments
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
   end


### PR DESCRIPTION
Magic comments at the beginning of the script can now be used to set additional options for the job. The script must start with a shebang and then followed by the magic comments. E.g.

```
#!/bin/bash
#SBATCH -N 1000
```

The default prefix is `SBATCH` but this can be changed with the `-C` CLI option or via the config.

Based on #2, please merge it first