### PR TITLE
Display the allocated-nodes and job state

### DIFF
--- a/lib/flight_scheduler/commands/info.rb
+++ b/lib/flight_scheduler/commands/info.rb
@@ -32,11 +32,11 @@ module FlightScheduler
 
       # Wraps the partition object after it's nodes have been filtered by a state
       class PartitionProxy < SimpleDelegator
-        attr_reader :state, :filtered_nodes
+        attr_reader :state, :nodes
 
-        def initialize(partition, state: 'IDLE', filtered_nodes: [])
+        def initialize(partition, state: 'IDLE', nodes: [])
           @state = state
-          @filtered_nodes = filtered_nodes
+          @nodes = nodes
           super(partition)
         end
       end
@@ -44,9 +44,9 @@ module FlightScheduler
       register_column(header: 'PARTITION') { |p| p.name }
       register_column(header: 'AVAIL') { |_| 'TBD' }
       register_column(header: 'TIMELIMIT') { |_| 'TBD' }
-      register_column(header: 'NODES') { |p| p.filtered_nodes.length }
+      register_column(header: 'NODES') { |p| p.nodes.length }
       register_column(header: 'STATE') { |p| p.state }
-      register_column(header: 'NODELIST') { |p| p.filtered_nodes.map(&:name).join(',') }
+      register_column(header: 'NODELIST') { |p| p.nodes.map(&:name).join(',') }
 
       def run
         records = PartitionsRecord.fetch_all(includes: ['nodes'], connection: connection)
@@ -60,7 +60,7 @@ module FlightScheduler
             PartitionProxy.new(record)
           else
             hash.map do |state, nodes|
-              PartitionProxy.new(record, state: state, filtered_nodes: nodes)
+              PartitionProxy.new(record, state: state, nodes: nodes)
             end
           end
         end.flatten

--- a/lib/flight_scheduler/commands/info.rb
+++ b/lib/flight_scheduler/commands/info.rb
@@ -35,10 +35,10 @@ module FlightScheduler
       register_column(header: 'TIMELIMIT') { |_| 'TBD' }
       register_column(header: 'NODES') { |p| p.nodes.length }
       register_column(header: 'STATE') { |_| 'TBD' }
-      register_column(header: 'NODELIST') { |p| p.nodes.join(',') }
+      register_column(header: 'NODELIST') { |p| p.nodes.map(&:name).join(',') }
 
       def run
-        records = PartitionsRecord.fetch_all(connection: connection)
+        records = PartitionsRecord.fetch_all(includes: ['nodes'], connection: connection)
         puts self.class.build_output.render(*records)
       end
     end

--- a/lib/flight_scheduler/commands/queue.rb
+++ b/lib/flight_scheduler/commands/queue.rb
@@ -37,10 +37,10 @@ module FlightScheduler
       register_column(header: 'ST') { |j| j.state }
       register_column(header: 'TIME') { |_| 'TBD' }
       register_column(header: 'NODES') { |j| j.min_nodes || j.attributes[:'min-nodes'] }
-      register_column(header: 'NODELIST(REASON)') { |j| j.attributes[:'allocated-nodes'].join(',') }
+      register_column(header: 'NODELIST(REASON)') { |j| j.relationships[:'allocated-nodes'].map(&:name).join(',') }
 
       def run
-        records = JobsRecord.fetch_all(includes: ['partition'], connection: connection)
+        records = JobsRecord.fetch_all(includes: ['partition', 'allocated-nodes'], connection: connection)
         puts self.class.build_output.render(*records)
       end
     end

--- a/lib/flight_scheduler/commands/queue.rb
+++ b/lib/flight_scheduler/commands/queue.rb
@@ -34,10 +34,10 @@ module FlightScheduler
       register_column(header: 'PARTITION') { |j| j.partition.name }
       register_column(header: 'NAME') { |j| File.basename(j.script) }
       register_column(header: 'USER') { |_| 'TBD' }
-      register_column(header: 'ST') { |_| 'TBD' }
+      register_column(header: 'ST') { |j| j.state }
       register_column(header: 'TIME') { |_| 'TBD' }
       register_column(header: 'NODES') { |j| j.min_nodes || j.attributes[:'min-nodes'] }
-      register_column(header: 'NODELIST(REASON)') { |_| 'TBD' }
+      register_column(header: 'NODELIST(REASON)') { |j| j.attributes[:'allocated-nodes'].join(',') }
 
       def run
         records = JobsRecord.fetch_all(includes: ['partition'], connection: connection)

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -43,7 +43,7 @@ module FlightScheduler
   end
 
   class NodesRecord < BaseRecord
-    attributes :name
+    attributes :name, :state
   end
 
   class JobsRecord < BaseRecord

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -38,6 +38,8 @@ module FlightScheduler
 
   class PartitionsRecord < BaseRecord
     attributes :name, :nodes
+
+    has_many :nodes, class_name: 'FlightScheduler::NodesRecord'
   end
 
   class NodesRecord < BaseRecord

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -41,7 +41,7 @@ module FlightScheduler
   end
 
   class JobsRecord < BaseRecord
-    attributes :min_nodes, :script, :arguments
+    attributes :min_nodes, :script, :arguments, :state
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
   end

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -40,10 +40,15 @@ module FlightScheduler
     attributes :name, :nodes
   end
 
+  class NodesRecord < BaseRecord
+    attributes :name
+  end
+
   class JobsRecord < BaseRecord
     attributes :min_nodes, :script, :arguments, :state
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
+    has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'
   end
 end
 


### PR DESCRIPTION
The `queue` output now contains the state (`ST`) and the `NODELIST` of allocated nodes.

The `info` output has been upgraded to display an entry for each `partition`-"node-state" combination. This allows the `STATE` and NODELIST` to be updated accordingly.

This has all be made possible with the new `NodesRecord` which contains the state information. This does mean the client needs to generate the `partition`-"node state" combinations as this does not correspond with an API resource. This operation is O(PN) so can be considered reasonable quick. It maybe possible to reduce the complexity to O(P+N)