### PR TITLE
Add `--array` option to submit array jobs

### DIFF
--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -72,6 +72,12 @@ module FlightScheduler
     MAGIC_BATCH_SLOP = Slop::Options.new.tap do |slop|
       slop.parser.config[:suppress_errors] = true
       slop.string '-N', '--nodes', 'The minimum number of required nodes'
+      slop.string '-a', '--array', <<~EOF
+        Submit a job array, multiple jobs to be  executed  with  identical
+        parameters.  The indexes  specification  identifies  what  array index
+        values should be used. Multiple values may be specified using a comma
+        separated list, e.g., --array=1,2,3,4.
+      EOF
     end
 
     create_command 'batch', 'SCRIPT [ARGS...]' do |c|

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -35,6 +35,7 @@ module FlightScheduler
         job = JobsRecord.create(arguments: args[1..-1],
                                 script_name: File.basename(script_path),
                                 script: script_body,
+                                array: merged_opts.array,
                                 min_nodes: min_nodes,
                                 connection: connection)
         puts "Submitted batch job #{job.id}"

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -47,7 +47,13 @@ module FlightScheduler
   end
 
   class JobsRecord < BaseRecord
-    attributes :min_nodes, :script, :script_name, :arguments, :state, :reason
+    attributes :arguments,
+      :array,
+      :min_nodes,
+      :reason,
+      :script,
+      :script_name,
+      :state
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
     has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'


### PR DESCRIPTION
This PR adds support for submitting array jobs to the scheduler.  The supported syntax for the `--array` option is a comma-separated list of indexes, e.g., `--array 0,1,2,3,4` or `--array 2,4,6,8`.  The error reporting if the given option is invalid still needs to be added.