### PR TITLE
Display the reason why a job isn't running

### DIFF
--- a/lib/flight_scheduler/commands/queue.rb
+++ b/lib/flight_scheduler/commands/queue.rb
@@ -37,7 +37,14 @@ module FlightScheduler
       register_column(header: 'ST') { |j| j.state }
       register_column(header: 'TIME') { |_| 'TBD' }
       register_column(header: 'NODES') { |j| j.min_nodes || j.attributes[:'min-nodes'] }
-      register_column(header: 'NODELIST(REASON)') { |j| j.relationships[:'allocated-nodes'].map(&:name).join(',') }
+      register_column(header: 'NODELIST(REASON)') do |job|
+        nodes = job.relationships[:'allocated-nodes'].map(&:name).join(',')
+        if job.reason
+          "#{nodes} (#{job.reason})"
+        else
+          nodes
+        end
+      end
 
       def run
         records = JobsRecord.fetch_all(includes: ['partition', 'allocated-nodes'], connection: connection)

--- a/lib/flight_scheduler/commands/queue.rb
+++ b/lib/flight_scheduler/commands/queue.rb
@@ -39,7 +39,9 @@ module FlightScheduler
       register_column(header: 'NODES') { |j| j.min_nodes || j.attributes[:'min-nodes'] }
       register_column(header: 'NODELIST(REASON)') do |job|
         nodes = job.relationships[:'allocated-nodes'].map(&:name).join(',')
-        if job.reason
+        if job.reason && nodes.empty?
+          "(#{job.reason})"
+        elsif job.reason
           "#{nodes} (#{job.reason})"
         else
           nodes

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -47,7 +47,7 @@ module FlightScheduler
   end
 
   class JobsRecord < BaseRecord
-    attributes :min_nodes, :script, :arguments, :state
+    attributes :min_nodes, :script, :arguments, :state, :reason
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
     has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'


### PR DESCRIPTION
The reason is displayed along with the nodes list. Technically these two fields exist in an XOR relationship, however this is enforced server side.

As far as the client is concerned, the two fields (`nodelist` and `reason`) could be displayed together and handles the output as such.