### PR TITLE
Display the tasks in the queue output

### DIFF
--- a/lib/flight_scheduler/commands/queue.rb
+++ b/lib/flight_scheduler/commands/queue.rb
@@ -32,7 +32,15 @@ module FlightScheduler
 
       INCLUDES = ['partition', 'allocated-nodes', 'running-tasks', 'running-tasks.allocated-nodes']
 
-      register_column(header: 'JOBID') { |j| j.id }
+      register_column(header: 'JOBID') do |r|
+        if r.is_a?(JobsRecord) && r.attributes[:'last-index']
+          "#{r.id}[#{r.attributes[:'next-index']}-#{r.attributes[:'last-index']}]"
+        elsif r.is_a? JobsRecord
+          r.id
+        else
+          "#{r.job.id}[#{r.index}]"
+        end
+      end
       register_column(header: 'PARTITION') do |r|
         (r.is_a?(TasksRecord) ? r.job : r).partition.name
       end

--- a/lib/flight_scheduler/commands/queue.rb
+++ b/lib/flight_scheduler/commands/queue.rb
@@ -33,10 +33,14 @@ module FlightScheduler
       INCLUDES = ['partition', 'allocated-nodes', 'running-tasks', 'running-tasks.allocated-nodes']
 
       register_column(header: 'JOBID') do |r|
-        if r.is_a?(JobsRecord) && r.attributes[:'last-index']
-          "#{r.id}[#{r.attributes[:'next-index']}-#{r.attributes[:'last-index']}]"
-        elsif r.is_a? JobsRecord
-          r.id
+        if r.is_a?(JobsRecord)
+          if r.attributes[:'next-index'].nil?
+            r.id
+          elsif r.attributes[:'next-index'] == r.attributes[:'last-index']
+            "#{r.id}[#{r.attributes[:'next-index']}]"
+          else
+            "#{r.id}[#{r.attributes[:'next-index']}-#{r.attributes[:'last-index']}]"
+          end
         else
           "#{r.job.id}[#{r.index}]"
         end

--- a/lib/flight_scheduler/commands/queue.rb
+++ b/lib/flight_scheduler/commands/queue.rb
@@ -30,27 +30,44 @@ module FlightScheduler
     class Queue < Command
       extend OutputMode::TLDR::Index
 
+      INCLUDES = ['partition', 'allocated-nodes', 'running-tasks', 'running-tasks.allocated-nodes']
+
       register_column(header: 'JOBID') { |j| j.id }
-      register_column(header: 'PARTITION') { |j| j.partition.name }
-      register_column(header: 'NAME') { |j| j.attributes[:'script-name'] }
+      register_column(header: 'PARTITION') do |r|
+        (r.is_a?(TasksRecord) ? r.job : r).partition.name
+      end
+      register_column(header: 'NAME') do |r|
+        r.attributes[:'script-name']
+      end
       register_column(header: 'USER') { |_| 'TBD' }
       register_column(header: 'ST') { |j| j.state }
       register_column(header: 'TIME') { |_| 'TBD' }
       register_column(header: 'NODES') { |j| j.min_nodes || j.attributes[:'min-nodes'] }
-      register_column(header: 'NODELIST(REASON)') do |job|
-        nodes = job.relationships[:'allocated-nodes'].map(&:name).join(',')
-        if job.reason && nodes.empty?
-          "(#{job.reason})"
-        elsif job.reason
-          "#{nodes} (#{job.reason})"
-        else
+      register_column(header: 'NODELIST(REASON)') do |record|
+        nodes = record.relationships[:'allocated-nodes'].map(&:name).join(',')
+        if record.is_a?(TasksRecord)
           nodes
+        else
+          if record.reason && nodes.empty?
+            "(#{record.reason})"
+          elsif record.reason
+            "#{nodes} (#{record.reason})"
+          else
+            nodes
+          end
         end
       end
 
       def run
-        records = JobsRecord.fetch_all(includes: ['partition', 'allocated-nodes'], connection: connection)
-        puts self.class.build_output.render(*records)
+        records = JobsRecord.fetch_all(includes: INCLUDES, connection: connection)
+        jobs_and_tasks = records.map do |record|
+          if record.attributes[:'last-index']
+            [record, record.relationships[:'running-tasks'].each { |t| t.job = record }]
+          else
+            record_proxy
+          end
+        end.flatten.reject(&:nil?)
+        puts self.class.build_output.render(*jobs_and_tasks)
       end
     end
   end

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -47,6 +47,11 @@ module FlightScheduler
   end
 
   class JobsRecord < BaseRecord
+    # Used to abstract the difference between tasks and jobs
+    def job
+      self
+    end
+
     attributes :arguments,
       :array,
       :min_nodes,

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -57,6 +57,15 @@ module FlightScheduler
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
     has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'
+
+    has_many :'running-tasks', class_name: 'FlightScheduler::TasksRecord'
+  end
+
+  class TasksRecord < BaseRecord
+    attributes :state, :min_nodes, :index
+
+    has_one :job, class_name: 'FlightScheduler::JobsRecord'
+    has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'
   end
 end
 


### PR DESCRIPTION
This PR splits the `tasks` from the `jobs` in the queue output. It took a bit of logic to distinguish between tasks/jobs