### PR TITLE
Add the --output and --error flags

### DIFF
--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -78,6 +78,8 @@ module FlightScheduler
         values should be used. Multiple values may be specified using a comma
         separated list, e.g., --array=1,2,3,4.
       EOF
+      slop.string '-o', '--output', 'Redirect STDOUT to this path'
+      slop.string '-e', '--error', 'Redirect STDERR to this path'
     end
 
     create_command 'batch', 'SCRIPT [ARGS...]' do |c|

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -37,6 +37,8 @@ module FlightScheduler
                                 script: script_body,
                                 array: merged_opts.array,
                                 min_nodes: min_nodes,
+                                stdout_path: opts.output,
+                                stderr_path: opts.error,
                                 connection: connection)
         puts "Submitted batch job #{job.id}"
       end

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -58,7 +58,9 @@ module FlightScheduler
       :reason,
       :script,
       :script_name,
-      :state
+      :state,
+      :stdout_path,
+      :stderr_path
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
     has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'


### PR DESCRIPTION
This is fairly straight forward PR which allows job's to set the stdout and stderr paths.

At some future point the help text needs to be updated with the valid replacements. However these options are currently volatile and are liable to change. Once the API stabilises the help text can be revisited. 