### PR TITLE
First pass at alloc command

### DIFF
--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -98,6 +98,13 @@ module FlightScheduler
       c.summary = 'List all current jobs'
     end
 
+    create_command 'alloc' do |c|
+      c.summary = 'Obtain a resource allocation'
+      c.slop.string '-N', '--nodes',
+                    'The minimum number of required nodes',
+                    default: 1
+    end
+
     if Config::CACHE.development?
       create_command 'console' do |c|
         require_relative 'commands'

--- a/lib/flight_scheduler/commands/alloc.rb
+++ b/lib/flight_scheduler/commands/alloc.rb
@@ -1,0 +1,44 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of Flight Scheduler.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Scheduler is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Scheduler. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Scheduler, please visit:
+# https://github.com/openflighthpc/flight-scheduler
+#===============================================================================
+
+module FlightScheduler
+  module Commands
+    class Alloc < Command
+      def run
+        job = JobsRecord.create(
+          min_nodes: opts.nodes,
+          connection: connection,
+        )
+        # XXX It might not be queued.  It could have been immediately
+        # allocated resources.  We should handle that here and add additional
+        # output as the job changes state.  Perhaps, websockety goodness is
+        # needed here.
+        puts "Job #{job.id} queued and waiting for resources"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, it creates a job without an attached batch script.

The following are features that it does not currently support, but should do:

 1. Take a command to exectue, e.g., `bash`.
 2. Provide better feedback on the state of the job.
 3. Run the command when the job is allocated resources, in a suitable environment.
 4. Release the allocation / complete the job when the command exits.