### PR TITLE
Run command connects input/output to job step ; giving us interactive sessions

### DIFF
--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -98,8 +98,8 @@ module FlightScheduler
       c.summary = 'List all current jobs'
     end
 
-    create_command 'alloc' do |c|
-      c.summary = 'Obtain a resource allocation'
+    create_command 'alloc', '[COMMAND] [ARGS...]' do |c|
+      c.summary = 'Obtain a resource allocation, execute the given command and release the allocation when the command is finished.'
       c.slop.string '-N', '--nodes',
                     'The minimum number of required nodes',
                     default: 1

--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -109,6 +109,8 @@ module FlightScheduler
       c.summary = 'Run EXECUTABLE under an already allocated job'
       c.slop.string '--jobid',
                     'Run under an already allocated job'
+      c.slop.bool '--pty',
+                    'Execute task zero in pseudo terminal mode.'
     end
 
     if Config::CACHE.development?

--- a/lib/flight_scheduler/commands/alloc.rb
+++ b/lib/flight_scheduler/commands/alloc.rb
@@ -38,6 +38,27 @@ module FlightScheduler
         # output as the job changes state.  Perhaps, websockety goodness is
         # needed here.
         puts "Job #{job.id} queued and waiting for resources"
+        # XXX Replace this with a sane way of detecting if the resources have
+        # been allocated.
+        sleep 1
+        puts "Job #{job.id} allocated resources"
+        run_command_and_wait(job)
+        job.delete
+        puts "Job #{job.id} resources deallocated"
+      end
+
+      def run_command_and_wait(job)
+        command = args.first || 'bash'
+        child_pid = Kernel.fork do
+          opts = {
+            unsetenv_others: false,
+          }
+          env = {
+            'JOB_ID' => job.id,
+          }
+          Kernel.exec(env, command, *args[1..-1], **opts)
+        end
+        Process.wait(child_pid)
       end
     end
   end

--- a/lib/flight_scheduler/commands/run.rb
+++ b/lib/flight_scheduler/commands/run.rb
@@ -36,6 +36,59 @@ module FlightScheduler
           connection: connection,
         )
         puts "Job step #{job_step.id} added"
+        sleep 1
+
+        job_step = JobStepsRecord.fetch(
+          includes: ['executions'],
+          connection: connection,
+          url_opts: { id: "#{job_id}.#{job_step.id}" },
+        )
+
+        puts "Job step running"
+        job_step.executions.each do |execution|
+          connect_to_session(execution.node, execution.port)
+        end
+      end
+
+      def connect_to_session(hostname, port)
+        begin
+          Thread.report_on_exception = false
+          connection = TCPSocket.new(hostname, port)
+
+          input_thread = Thread.new do
+            begin
+              IO.copy_stream(STDIN, connection)
+            rescue IOError, Errno::EBADF
+            ensure
+              connection.close_write
+            end
+          end
+          output_thread = Thread.new do
+            begin
+              IO.copy_stream(connection, STDOUT)
+            rescue IOError, Errno::EBADF
+            ensure
+              # If the connection is closed by the server, we'll end up here.
+              # However, input_thread will remain blocked at the
+              # `IO.copy_stream` call.  To exit cleanly we need to kill the
+              # thread.
+              input_thread.kill
+            end
+          end
+
+          input_thread.join
+          output_thread.join
+
+        rescue Interrupt
+          if Kernel.const_defined?(:Paint)
+            $stderr.puts "\n#{Paint['WARNING', :underline, :yellow]}: Cancelled by user"
+          else
+            $stderr.puts "\nWARNING: Cancelled by user"
+          end
+          exit(130)
+        ensure
+          connection.close if connection
+        end
       end
 
       def job_id

--- a/lib/flight_scheduler/commands/run.rb
+++ b/lib/flight_scheduler/commands/run.rb
@@ -41,6 +41,8 @@ module FlightScheduler
       def job_id
         if opts.jobid
           opts.jobid
+        elsif ENV['JOB_ID']
+          ENV['JOB_ID']
         else
           raise InputError, <<~ERROR.chomp
             --jobid must be given

--- a/lib/flight_scheduler/commands/run.rb
+++ b/lib/flight_scheduler/commands/run.rb
@@ -90,16 +90,19 @@ module FlightScheduler
       end
 
       def create_input_thread(connections)
+        report_on_exception = Config::CACHE.log_level == 'debug'
         if pty?
           # Currently we only support PTY sessions on a single node.
           write_pipe = connections.first.write_pipe
           Thread.new do
+            Thread.current.report_on_exception = report_on_exception
             STDIN.raw do |stdin|
               IO.copy_stream(stdin, write_pipe)
             end
           end
         else
           Thread.new do
+            Thread.current.report_on_exception = report_on_exception
             begin
               loop do
                 if STDIN.eof? || STDIN.closed?

--- a/lib/flight_scheduler/commands/run.rb
+++ b/lib/flight_scheduler/commands/run.rb
@@ -131,14 +131,6 @@ module FlightScheduler
 
         connections.each(&:join)
         input_thread.kill if input_thread && input_thread.alive?
-      rescue Interrupt
-        if Kernel.const_defined?(:Paint)
-          $stderr.puts "\n#{Paint['WARNING', :underline, :yellow]}: Cancelled by user"
-        else
-          $stderr.puts "\nWARNING: Cancelled by user"
-        end
-        exit(130)
-
       ensure
         connections.each(&:close) if connections
       end

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -74,8 +74,9 @@ module FlightScheduler
 
   class JobStepsRecord < BaseRecord
     attributes :arguments,
+      :job_id,
       :path,
-      :job_id
+      :pty
 
     has_one :job, class_name: 'FlightScheduler::JobsRecord'
     has_many :executions, class_name: 'FlightScheduler::ExecutionsRecord'

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -78,6 +78,13 @@ module FlightScheduler
       :job_id
 
     has_one :job, class_name: 'FlightScheduler::JobsRecord'
+    has_many :executions, class_name: 'FlightScheduler::ExecutionsRecord'
+  end
+
+  class ExecutionsRecord < BaseRecord
+    attributes :node,
+      :port,
+      :state
   end
 
   class TasksRecord < BaseRecord

--- a/lib/flight_scheduler/stepd_connection.rb
+++ b/lib/flight_scheduler/stepd_connection.rb
@@ -48,11 +48,13 @@ module FlightScheduler
     end
 
     def connect_to_command
-      Thread.report_on_exception = true
+      report_on_exception = Config::CACHE.log_level == 'debug'
       @thread = Thread.new do
+        Thread.current.report_on_exception = report_on_exception
         connection = TCPSocket.new(@execution.node, @execution.port)
 
         input_thread = Thread.new do
+          Thread.current.report_on_exception = report_on_exception
           begin
             IO.copy_stream(@read_pipe, connection)
           rescue IOError, Errno::EBADF, Errno::EPIPE, Errno::EIO
@@ -63,6 +65,7 @@ module FlightScheduler
           end
         end
         output_thread = Thread.new do
+          Thread.current.report_on_exception = report_on_exception
           begin
             IO.copy_stream(connection, STDOUT)
           rescue IOError, Errno::EBADF, Errno::EPIPE, Errno::EIO

--- a/lib/flight_scheduler/stepd_connection.rb
+++ b/lib/flight_scheduler/stepd_connection.rb
@@ -1,0 +1,84 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of Flight Scheduler.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Scheduler is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Scheduler. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Scheduler, please visit:
+# https://github.com/openflighthpc/flight-scheduler
+#===============================================================================
+module FlightScheduler
+  # A connection to the input/output of a single job step.
+  #
+  # Data written to `@write_pipe` is streamed through the connection to the
+  # job step.
+  #
+  # Data read from the connection is streamed to `STDOUT`.
+  class StepdConnection
+    attr_reader :write_pipe
+
+    def initialize(execution)
+      @execution = execution
+      @read_pipe, @write_pipe = IO.pipe
+    end
+
+    def close
+      @write_pipe.close_write
+    end
+
+    def join
+      @thread.join
+    end
+
+    def connect_to_command
+      Thread.report_on_exception = true
+      @thread = Thread.new do
+        connection = TCPSocket.new(@execution.node, @execution.port)
+
+        input_thread = Thread.new do
+          begin
+            IO.copy_stream(@read_pipe, connection)
+          rescue IOError, Errno::EBADF, Errno::EPIPE, Errno::EIO
+            # These exceptions are not unexpected.  We just want to
+            # silence them.
+          ensure
+            connection.close_write
+          end
+        end
+        output_thread = Thread.new do
+          begin
+            IO.copy_stream(connection, STDOUT)
+          rescue IOError, Errno::EBADF, Errno::EPIPE, Errno::EIO
+          ensure
+            # If the connection is closed by the server, we'll end up here.
+            # However, input_thread will remain blocked at the
+            # `IO.copy_stream` call.  To exit cleanly we need to kill the
+            # thread.
+            input_thread.kill
+          end
+        end
+        input_thread.join
+        output_thread.join
+      ensure
+        connection.close if connection
+      end
+    end
+  end
+end


### PR DESCRIPTION
* `alloc` now runs a command once the job is allocated resources and cleans up the job once the command completes.
* `run` connects its STDIN to the STDIN of all executions of the job step and connects all of the executions STDOUT to its STDOUT.
* If a PTY session is requested, only a single execution of the job step is created (this is enforced by the controller).  We don't do anything special here to support multiple PTY sessions connected to a single STDIN/STDOUT.

A number of shortcuts have been taken in this implementation which need addressing:

* We don't correctly determine if/when the job created by `alloc` has been allocated resources.
* We don't correctly determine if/when the step created by `run` has started to run on the node(s).
* We don't set the environment correctly for the process execd by `alloc`.  It contains just enough to make using `run` easy, but it should have the same environment that is used for running batch scripts / job steps on the daemons.
* We assume that the node name is the hostname that we should connect to.  This is a reasonable assumption in most cases, but eventually, we'll run into a setup where it isn't.