### PR TITLE
Miscellaneous minor fixes

### DIFF
--- a/etc/config.reference
+++ b/etc/config.reference
@@ -84,3 +84,9 @@ config :log_path, default: "#{xdg.cache_home}/flight/log/share/scheduler.log",
 # Valid levels: 'disabled', 'fatal', 'error', 'warn', 'info', 'debug'
 # ==============================================================================
 config :log_level, default: 'error'
+
+# ==============================================================================
+# Env var prefix
+# The prefix used for environment variables set in a job's context.
+# ==============================================================================
+config :env_var_prefix, default: ''

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -37,8 +37,8 @@ module FlightScheduler
                                 script: script_body,
                                 array: merged_opts.array,
                                 min_nodes: min_nodes,
-                                stdout_path: opts.output,
-                                stderr_path: opts.error,
+                                stdout_path: merged_opts.output,
+                                stderr_path: merged_opts.error,
                                 connection: connection)
         # TODO: Remove the id array stripping, this is a bug in the API
         #       specification

--- a/lib/flight_scheduler/commands/queue.rb
+++ b/lib/flight_scheduler/commands/queue.rb
@@ -39,7 +39,7 @@ module FlightScheduler
       register_column(header: 'NAME') do |r|
         r.job.attributes[:'script-name']
       end
-      register_column(header: 'USER') { |_| 'TBD' }
+      register_column(header: 'USER') { |j| j.username }
       register_column(header: 'ST') { |j| j.state }
       register_column(header: 'TIME') { |_| 'TBD' }
       register_column(header: 'NODES') { |j| j.attributes[:'min-nodes'] }

--- a/lib/flight_scheduler/commands/run.rb
+++ b/lib/flight_scheduler/commands/run.rb
@@ -38,7 +38,7 @@ module FlightScheduler
           pty: pty?,
           connection: connection,
         )
-        puts "Job step #{job_step.id} added"
+        $stderr.puts "Job step #{job_step.id} added"
         # Wait for the executions to have started running on all nodes.
         # XXX Replace this with a sane method.
         sleep 1
@@ -47,7 +47,7 @@ module FlightScheduler
           connection: connection,
           url_opts: { id: "#{job_id}.#{job_step.id}" },
         )
-        puts "Job step running"
+        $stderr.puts "Job step running"
         if pty? && job_step.executions.length > 1
           # If we're running a PTY session, we expect to have only a single
           # execution running.  Whilst it might be possible to send STDIN to
@@ -66,10 +66,11 @@ module FlightScheduler
       private
 
       def job_id
+        job_id_env_var = "#{Config::CACHE.env_var_prefix}JOB_ID"
         if opts.jobid
           opts.jobid
-        elsif ENV['JOB_ID']
-          ENV['JOB_ID']
+        elsif ENV[job_id_env_var]
+          ENV[job_id_env_var]
         else
           raise InputError, <<~ERROR.chomp
             --jobid must be given

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -64,7 +64,8 @@ module FlightScheduler
       :script_name,
       :state,
       :stdout_path,
-      :stderr_path
+      :stderr_path,
+      :username
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
     has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'


### PR DESCRIPTION
* Support `--output` and `--error` options as magic comments.
* Include job username in queue output.
* Don't mix `run` progress with step output.
* Use correct prefix for `JOB_ID` env var.