### PR TITLE
Implement a --format flag on the info command

### DIFF
--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -73,10 +73,10 @@ module FlightScheduler
 
         #{Commands::Info::Lister::OTHER_FIELDS.map { |k, v| "* #{k}: #{v}" }.join("\n")}
 
-        The following field is available when listing the partitions (default):
+        The following field will list each partition individually:
         #{Commands::Info::Lister::PARTITION_FIELDS.map { |k, v| "* #{k}: #{v}" }.join("\n")}
 
-        The following field will list each node individually. Can not be used with the partition field.
+        The following field will list each node individually:
         #{Commands::Info::Lister::NODE_FIELDS.map { |k, v| "* #{k}: #{v}" }.join("\n")}
       DESC
       c.slop.string '-o', '--format', <<~DESC.chomp
@@ -84,10 +84,10 @@ module FlightScheduler
 
         #{Commands::Info::Lister::OTHER_TYPES.map { |k, v| "* %#{k}: #{v}" }.join("\n")}
 
-        The following field is available when listing the partitions (default):
+        The following field will list each partition individually:
         #{Commands::Info::Lister::PARTITION_TYPES.map { |k, v| "* %#{k}: #{v}" }.join("\n")}
 
-        The following fields will list each node individually. Can not be used with the partition field.
+        The following field will list each node individually:
         #{Commands::Info::Lister::NODE_TYPES.map { |k, v| "* %#{k}: #{v}" }.join("\n")}
       DESC
     end

--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -67,7 +67,16 @@ module FlightScheduler
     end
 
     create_command 'info' do |c|
-      c.summary = 'List the available partitions'
+      c.summary = 'List the available partitions and nodes'
+      c.slop.string '-O', '--format', <<~DESC
+        Specify the format the information wil be displayed in. Must be comma separeted list of the following options:
+
+        * NodeList: All the nodes in the partition
+        * NodeHost: The name of each node individually
+        * CPUs: The number of cpus
+        * GPUs: The number of gpus
+        * Memory: The total amount of memory
+      DESC
     end
 
     MAGIC_BATCH_SLOP = Slop::Options.new.tap do |slop|

--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -30,6 +30,7 @@ require 'commander'
 require_relative 'config'
 require_relative 'version'
 require_relative 'auth'
+require_relative 'commands'
 
 module FlightScheduler
   class CLI
@@ -41,7 +42,6 @@ module FlightScheduler
         c.hidden if name.split.length > 1
 
         c.action do |args, opts|
-          require_relative 'commands'
           Commands.build(name, *args, **opts.to_h).run!
         end
 
@@ -68,16 +68,27 @@ module FlightScheduler
 
     create_command 'info' do |c|
       c.summary = 'List the available partitions and nodes'
-      c.slop.string '-O', '--format', <<~DESC
+      c.slop.string '-O', '--Format', <<~DESC.chomp
         Specify the format the information wil be displayed in. Must be comma separeted list of the following options:
 
-        * CPUs: The number of cpus
-        * GPUs: The number of gpus
-        * Memory: The total amount of memory
-        * NodeList: All the nodes in the partition
-        * NodeHost: The name of each node individually
-        * Partition: The name of the partition
-        * State: The state of the node(s)
+        #{Commands::Info::Lister::OTHER_FIELDS.map { |k, v| "* #{k}: #{v}" }.join("\n")}
+
+        The following field is available when listing the partitions (default):
+        #{Commands::Info::Lister::PARTITION_FIELDS.map { |k, v| "* #{k}: #{v}" }.join("\n")}
+
+        The following field will list each node individually. Can not be used with the partition field.
+        #{Commands::Info::Lister::NODE_FIELDS.map { |k, v| "* #{k}: #{v}" }.join("\n")}
+      DESC
+      c.slop.string '-o', '--format', <<~DESC.chomp
+        Specify the format the information wil be displayed in:
+
+        #{Commands::Info::Lister::OTHER_TYPES.map { |k, v| "* %#{k}: #{v}" }.join("\n")}
+
+        The following field is available when listing the partitions (default):
+        #{Commands::Info::Lister::PARTITION_TYPES.map { |k, v| "* %#{k}: #{v}" }.join("\n")}
+
+        The following fields will list each node individually. Can not be used with the partition field.
+        #{Commands::Info::Lister::NODE_TYPES.map { |k, v| "* %#{k}: #{v}" }.join("\n")}
       DESC
     end
 

--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -71,11 +71,13 @@ module FlightScheduler
       c.slop.string '-O', '--format', <<~DESC
         Specify the format the information wil be displayed in. Must be comma separeted list of the following options:
 
-        * NodeList: All the nodes in the partition
-        * NodeHost: The name of each node individually
         * CPUs: The number of cpus
         * GPUs: The number of gpus
         * Memory: The total amount of memory
+        * NodeList: All the nodes in the partition
+        * NodeHost: The name of each node individually
+        * Partition: The name of the partition
+        * State: The state of the node(s)
       DESC
     end
 

--- a/lib/flight_scheduler/commands/info.rb
+++ b/lib/flight_scheduler/commands/info.rb
@@ -226,23 +226,23 @@ module FlightScheduler
 
         def register_gpus
           register_nodes_column(header: 'GPUS') do |nodes|
-            value_or_min_plus(*nodes.map(&:gpus))
+            value_or_min_plus(*nodes.map(&:gpus), default: 0)
           end
         end
 
         def register_memory
           register_nodes_column(header: 'MEMORY (MB)') do |nodes|
-            value_or_min_plus(*nodes.map(&:gpus)) do |value|
+            value_or_min_plus(*nodes.map(&:memory), default: 1048576) do |value|
               # Convert the memory into MB
-              sprintf('%.2f', value.fdiv(1048576))
+              sprintf('%d', value.fdiv(1048576))
             end
           end
         end
 
-        def value_or_min_plus(*raws)
+        def value_or_min_plus(*raws, default: 1)
           # Ensures everything is an integer
-          # NOTE: Also assumes nil should be interpreted as 0
-          values = raws.map { |v| v.nil? ? 0 : v }
+          # Ignores nil values
+          values = raws.map { |v| v.nil? ? default : v }
 
           # Determine the minimum and maximum value
           min = values.min

--- a/lib/flight_scheduler/commands/info.rb
+++ b/lib/flight_scheduler/commands/info.rb
@@ -139,6 +139,11 @@ module FlightScheduler
 
         record_proxies = if lister.hostnames?
           # Create a one-to-one mapping between partitions and nodes
+          # NOTE: This section will duplicate nodes which are in multiple partitions
+          #       This may or may not be desirable depending if the 'Partitions' column
+          #       is being displayed.
+          #
+          #       Consider revisiting once the desired behaviour is determined
           records.map do |partition|
             partition.nodes.map { |n| PartitionProxy.new(partition, state: n.state, nodes: [n]) }
           end.flatten.uniq { |p| [p.id, p.nodes.first.id] }

--- a/lib/flight_scheduler/commands/info.rb
+++ b/lib/flight_scheduler/commands/info.rb
@@ -122,6 +122,10 @@ module FlightScheduler
                 list.register_gpus
               when 'Memory'
                 list.register_memory
+              when 'State'
+                list.register_state
+              when 'Partition'
+                list.register_partition
               end
             end
           end

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -69,7 +69,6 @@ module FlightScheduler
       :stderr_path,
       :username
 
-    has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
     has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'
   end
 

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -47,7 +47,9 @@ module FlightScheduler
   end
 
   class NodesRecord < BaseRecord
-    attributes :name, :state
+    attributes :name, :state, :cpus, :gpus, :memory
+
+    has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
   end
 
   class JobsRecord < BaseRecord


### PR DESCRIPTION
This change required a solution to the following problems:

1. The output's columns needed to be determined dynamically from a `--format` flag
2. The `NodeHost` options requires each line to represent a single node, and
3. Eventually all the columns will be used in arbitrary combinations

The first problem is fairly straight forward and required making a `Lister` object. Then each column is dynamically "registered" onto the Lister. Otherwise the table is generated in the same manner.

Reconciling problem 2 and 3 proved to be more challenging. Previously the table would show a "pseudo partition" (aka `PartitionProxy`) which grouped the `nodes` into `partitions` by their `state`. This means partitions are duplicated in the output if they contain nodes in multiple states. This needs to be maintained whenever `State` is specified.

However the `NodeHost` option causes each line in the output to represent a single `Node`. Ensure all the outputting options works for both a `Node` and a "pseudo partition" proved to be a herculean task and instead has been side stepped. Instead using `NodeHost` causes each `node` to be grouped into a "pseudo partition" by itself. This essentially changes the output to be on a per `node` basis whilst avoiding re-implementing the table.