### PR TITLE
Long poll for resources to be ready in alloc/run and set the environment

### DIFF
--- a/lib/flight_scheduler/commands/alloc.rb
+++ b/lib/flight_scheduler/commands/alloc.rb
@@ -37,10 +37,11 @@ module FlightScheduler
         # Long Poll until the job becomes available
         if job.runnable
           puts "Job #{job.id} queued and waiting for resources"
-          long_poll_id = "#{job.id}/long-poll-runnable"
+          con = connection.dup
+          con.params = { long_poll_runnable: true }
           while job.runnable
             job = JobsRecord.fetch(
-              connection: connection, url_opts: { id: long_poll_id }
+              connection: con, url_opts: { id: job.id }
             )
           end
         end

--- a/lib/flight_scheduler/commands/alloc.rb
+++ b/lib/flight_scheduler/commands/alloc.rb
@@ -36,11 +36,11 @@ module FlightScheduler
         )
 
         # Long Poll until the job becomes available
-        if job.runnable
+        if job.state == 'PENDING'
           puts "Job #{job.id} queued and waiting for resources"
           con = connection.dup
-          con.params = { long_poll_runnable: true }
-          while job.runnable
+          con.params = { long_poll_pending: true }
+          while job.state == 'PENDING'
             job = JobsRecord.fetch(
               connection: con, url_opts: { id: job.id }, includes: ['shared-environment']
             )

--- a/lib/flight_scheduler/commands/alloc.rb
+++ b/lib/flight_scheduler/commands/alloc.rb
@@ -45,6 +45,13 @@ module FlightScheduler
           end
         end
 
+        # Exit early if the job is not RUNNING
+        unless job.state == 'RUNNING'
+          raise GeneralError, <<~ERROR.chomp
+            Can not continue with the allocation as the job is in the #{job.state} state
+          ERROR
+        end
+
         puts "Job #{job.id} allocated resources"
         run_command_and_wait(job)
         job.delete

--- a/lib/flight_scheduler/commands/run.rb
+++ b/lib/flight_scheduler/commands/run.rb
@@ -40,7 +40,6 @@ module FlightScheduler
           pty: pty?,
           connection: create_con
         )
-        $stderr.puts "Job step #{job_step.id} added"
 
         # Long poll until the job step has been submitted to all nodes
         # NOTE: Sometimes the submission is sufficiently fast that this
@@ -55,7 +54,6 @@ module FlightScheduler
           )
         end
 
-        $stderr.puts "Job step running"
         if pty? && job_step.executions.length > 1
           # If we're running a PTY session, we expect to have only a single
           # execution running.  Whilst it might be possible to send STDIN to

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -78,7 +78,8 @@ module FlightScheduler
     attributes :arguments,
       :job_id,
       :path,
-      :pty
+      :pty,
+      :submitted
 
     has_one :job, class_name: 'FlightScheduler::JobsRecord'
     has_many :executions, class_name: 'FlightScheduler::ExecutionsRecord'

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -48,8 +48,6 @@ module FlightScheduler
 
   class NodesRecord < BaseRecord
     attributes :name, :state, :cpus, :gpus, :memory
-
-    has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
   end
 
   class JobsRecord < BaseRecord

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -67,7 +67,8 @@ module FlightScheduler
       :state,
       :stdout_path,
       :stderr_path,
-      :username
+      :username,
+      :runnable
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
     has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -65,8 +65,7 @@ module FlightScheduler
       :state,
       :stdout_path,
       :stderr_path,
-      :username,
-      :runnable
+      :username
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
     has_one :'shared-environment', class_name: 'FlightScheduler::EnvironmentsRecord'

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -71,6 +71,7 @@ module FlightScheduler
       :runnable
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'
+    has_one :'shared-environment', class_name: 'FlightScheduler::EnvironmentsRecord'
     has_many :'allocated-nodes', class_name: 'FlightScheduler::NodesRecord'
   end
 
@@ -89,5 +90,9 @@ module FlightScheduler
     attributes :node,
       :port,
       :state
+  end
+
+  class EnvironmentsRecord < BaseRecord
+    attributes :hash
   end
 end


### PR DESCRIPTION
Three new features have been added in this PR:

* The `alloc` command long polls the controller for whether the job is still `runnable`,
* The `run` command long polls for the job step to be `submitted`, and
* The `alloc` command now sets the environment similar to batch jobs.

HTTP long polling is being used as it proved to be a bit more straightforward then implementing web sockets. The length of the long poll is controlled server side, but is set to a 30 second timeout by default.

The `alloc` command uses a new concept of "runnability" instead of directly checking the state. A job is `runnable` iff it can transition into the `RUNNING` state. This provides better handling of `CANCELED` jobs as this will trigger `runnable` to be `false`. It also allows for additional states (such as `CONFIGURING`, `SUSPENDED`, `PREEMPTED`, `RESIZING`) to be added without having to modify the client. NOTE: A job in the `RUNNING` state is not `runnable` as it can not transition back into that state (i.e. a running job can not be reran).

The new `submitted` flag for a `job_step` is set once all the `nodes` have reported back they have started the `job_step`. Otherwise the poll is the same.