### PR TITLE
Allow the user to export environment variables

### DIFF
--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -103,6 +103,29 @@ module FlightScheduler
       EOF
       slop.string '-o', '--output', 'Redirect STDOUT to this path'
       slop.string '-e', '--error', 'Redirect STDERR to this path'
+      slop.string '--export', <<~EOF
+        Identify which environment variables from the submission environment
+        are propagated to the launched application.
+
+        --export=ALL
+        
+          Default mode if --export is not specified. All of the users
+          environment will be loaded from callers environment.
+          
+        --export=NONE
+        
+          No variables from the user environment will be defined.
+          
+        --export=<[ALL,]environment variables>
+          
+          Exports explicitly defined variables. Multiple environment variable
+          names should be comma separated. Environment variable names may be
+          specified to propagate the current value (e.g. "--export=EDITOR") or
+          specific values may be exported (e.g. "--export=EDITOR=/bin/emacs").
+          If ALL is specified, then all user environment variables will be
+          loaded and will take precedence over any explicitly given
+          environment variables.
+      EOF
     end
 
     create_command 'batch', 'SCRIPT [ARGS...]' do |c|
@@ -111,7 +134,6 @@ module FlightScheduler
       c.slop.string '-C', '--comment-prefix',
                     'Parse comment lines starting with COMMENT_PREFIX as additional options',
                     default: Config::CACHE.comment_prefix
-      c.slop.string '--export', 'Enviroment variables to export'
     end
 
     create_command 'cancel', 'JOBID' do |c|

--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -111,6 +111,7 @@ module FlightScheduler
       c.slop.string '-C', '--comment-prefix',
                     'Parse comment lines starting with COMMENT_PREFIX as additional options',
                     default: Config::CACHE.comment_prefix
+      c.slop.string '--export', 'Enviroment variables to export'
     end
 
     create_command 'cancel', 'JOBID' do |c|

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -61,7 +61,7 @@ module FlightScheduler
           # Convert the components into a hash
           others  = parts.each_with_object({}) do |part, memo|
             key, value = part.split('=', 2)
-            memo[key] = value || ENV[key]
+            memo[key] = value || ENV.fetch(key, '')
           end
 
           # Allow all the existing env vars to be exported

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -51,10 +51,10 @@ module FlightScheduler
       def environment
         Bundler.with_unbundled_env do
           # Default to displaying everthing
-          return ENV.to_h unless opts.export
+          return ENV.to_h unless merged_opts.export
 
           # Parse the string and remove the ALL and NONE component
-          parts   = CSV.parse(opts.export).first || []
+          parts   = CSV.parse(merged_opts.export).first || []
           all     = (parts.delete('ALL') ? true : false)
           parts.delete('NONE')
 

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -41,7 +41,7 @@ module FlightScheduler
                                 min_nodes: min_nodes,
                                 stdout_path: merged_opts.output,
                                 stderr_path: merged_opts.error,
-                                envs: environment,
+                                environment: environment,
                                 connection: connection)
         # TODO: Remove the id array stripping, this is a bug in the API
         #       specification

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -65,6 +65,7 @@ module FlightScheduler
       :state,
       :stdout_path,
       :stderr_path,
+      :envs,
       :username
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'

--- a/lib/flight_scheduler/records.rb
+++ b/lib/flight_scheduler/records.rb
@@ -58,14 +58,14 @@ module FlightScheduler
 
     attributes :arguments,
       :array,
+      :environment,
       :min_nodes,
       :reason,
       :script,
       :script_name,
       :state,
-      :stdout_path,
       :stderr_path,
-      :envs,
+      :stdout_path,
       :username
 
     has_one :partition, class_name: 'FlightScheduler::PartitionsRecord'


### PR DESCRIPTION
By default, batch jobs are now submitted with the user's environment, this equivalent to `--export ALL`.

Alternatively, selected parts of the environment can be exported with `--export existing_env_var,new_env=value`.

Or defaults can be added for keys not in the environment: `--export ALL,default_value=value`

Finally no values can be exported with: `--export NONE`