### PR TITLE
Display partitions without nodes by default

### DIFF
--- a/lib/flight_scheduler/commands/info.rb
+++ b/lib/flight_scheduler/commands/info.rb
@@ -310,6 +310,10 @@ module FlightScheduler
           # List the data as if partition-node exist in many-one relationship
           # TODO: Consider replacing with a nodes query
           nodes = records.map(&:nodes).flatten.uniq { |n| n.name }
+          if nodes.empty?
+            $stderr.puts '(none)'
+            return
+          end
           nodes.map do |node|
             [nil, [node]]
           end

--- a/lib/flight_scheduler/commands/info.rb
+++ b/lib/flight_scheduler/commands/info.rb
@@ -208,6 +208,7 @@ module FlightScheduler
         end
 
         # Assumes all the nodes have been grouped by state
+        # NOTE: Must be able to handle partitions without nodes
         def register_node_state
           @node_state = true
           register_nodes_column(header: 'STATE') do |nodes|
@@ -319,10 +320,14 @@ module FlightScheduler
           records.each_with_object([]) do |partition, memo|
             # Collect the nodes by their state
             hash = Hash.new { |h, v| h[v] = [] }
-            partition.nodes.each { |node| hash[node.state] << node }
+            if partition.nodes.empty?
+              hash['MISSING'] = []
+            else
+              partition.nodes.each { |node| hash[node.state] << node }
+            end
 
             # Create a proxy object for each partition-state combination
-            hash.map do |state, nodes|
+            hash.map do |_, nodes|
               memo << [partition, nodes]
             end
           end


### PR DESCRIPTION
Partitions without nodes weren't being displayed as they lacked a "node state". This has been fixed by allowing the "node state" to be missing.