### PR TITLE
First pass at specifying partition for a job

### DIFF
--- a/lib/flight_scheduler/cli.rb
+++ b/lib/flight_scheduler/cli.rb
@@ -100,6 +100,11 @@ module FlightScheduler
         Specify the minimum amount of memory per node.
         The default unit is MB, however a K|M|G|T suffix can be used to change the unit.
       EOF
+      slop.string '-p', '--partition', <<~EOF.chomp
+        Request a specific partition for the resource allocation.  If not
+        specified the default partition as designated by the system
+        administrator is selected.
+      EOF
       slop.string '--time', 'The period to timeout after'
     end
 

--- a/lib/flight_scheduler/command.rb
+++ b/lib/flight_scheduler/command.rb
@@ -35,6 +35,10 @@ require 'etc'
 
 module FlightScheduler
   class Command
+    class Options < Hashie::Mash
+      disable_warnings :partition
+    end
+
     def self.convert_time(seconds)
       return nil unless seconds
       days    = seconds / (60 * 60 * 24)
@@ -53,7 +57,7 @@ module FlightScheduler
 
     def initialize(*args, **opts)
       @args = args.freeze
-      @opts = Hashie::Mash.new(opts)
+      @opts = Options.new(opts)
     end
 
     def run!

--- a/lib/flight_scheduler/commands/batch.rb
+++ b/lib/flight_scheduler/commands/batch.rb
@@ -118,7 +118,7 @@ module FlightScheduler
           cli = opts.reject { |_, v| v.nil? }
                     .map { |k, v| [k.to_s, v] }
                     .to_h
-          Hashie::Mash.new.merge(magic).merge(cli)
+          Command::Options.new.merge(magic).merge(cli)
         end
       end
 


### PR DESCRIPTION
This PR adds support for specifying the partition that a job can run on.

Both the `alloc` and `batch` commands have gained a `-p`, `--partition` option.  This option can be used to specify a single partition for the job.  Slurm allows multiple partitions to be named and will select the first one that is able to schedule the job.  This is not currently supported by Flight Scheduler.

The options are converted to a `Hashie::Mash`.  `Hashie::Mash` includes `Enumerable` which already contains a `partition` method.  This has two issues:

 1. it results in an error warning being logged to stderr by `Hashie::Mash`.
 2. the partition option cannot be accessed as `opts.partition` instead it must be accessed as `opts[:partition]`.

This results in inconsistent access mechanism for the options, which needs to be remembered if we are ever iterating over all of the options....sighhhh...
